### PR TITLE
chore: add Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744168086,
+        "narHash": "sha256-S9M4HddBCxbbX1CKSyDYgZ8NCVyHcbKnBfoUXeRu2jQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "60e405b241edb6f0573f3d9f944617fe33ac4a73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -16,16 +16,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744168086,
-        "narHash": "sha256-S9M4HddBCxbbX1CKSyDYgZ8NCVyHcbKnBfoUXeRu2jQ=",
+        "lastModified": 1774388614,
+        "narHash": "sha256-tFwzTI0DdDzovdE9+Ras6CUss0yn8P9XV4Ja6RjA+nU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60e405b241edb6f0573f3d9f944617fe33ac4a73",
+        "rev": "1073dad219cb244572b74da2b20c7fe39cb3fa9e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,165 @@
+{
+  description = "gh-notifier devel and build";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+
+  # shell.nix compatibility
+  inputs.flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      # System types to support.
+      targetSystems = [ "x86_64-linux" "aarch64-linux" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs targetSystems;
+
+      inherit (nixpkgs) lib;
+      sharedOptionModule = { lib, pkgs, ... }: {
+        options.services.gh-notifier = {
+          enable = lib.mkEnableOption "GitHub Notifications notifier for Linux";
+          package = lib.mkOption {
+            type = lib.types.package;
+            default = self.packages.${pkgs.system}.default;
+            defaultText = lib.literalMD "`gh-notifier` from the flake defining this module";
+            description = ''
+              Package to use.
+            '';
+          };
+          systemdTarget = lib.mkOption {
+            type = lib.types.str;
+            default = "graphical-session.target";
+            example = "sway-session.target";
+            description = ''
+              Systemd target to bind to.
+            '';
+          };
+          environmentFile = lib.mkOption {
+            type = lib.types.path;
+            description = ''
+              The full path to a file which contains environment variables as defined in {manpage}`systemd.exec(5)`.
+
+              The GitHub token ({env}`GITHUB_TOKEN`) should be specified in the
+              file this option points to. The token can either be a classic
+              personal access token (PAT) or an OAuth app's access token.
+
+              Create a matching classic PAT
+              [here](https://github.com/settings/tokens/new?description=gh-notifier&scopes=read%3Auser%2Cnotifications%2Crepo).
+
+              Example file contents:
+              ```
+              GITHUB_TOKEN=ghp_...
+              ```
+            '';
+            example = "/run/secrets/github-notifier.env";
+          };
+        };
+      };
+    in {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage rec {
+            pname = "gh-notifier";
+            version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+
+            src = ./.;
+
+            cargoLock.lockFile = ./Cargo.lock;
+
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              makeBinaryWrapper
+            ];
+
+            buildInputs = with pkgs; [
+              openssl
+            ];
+
+            postInstall = ''
+              wrapProgram $out/bin/gh-notifier \
+                --suffix PATH : ${nixpkgs.lib.makeBinPath [ pkgs.xdg-utils ]}
+            '';
+
+            meta = with nixpkgs.lib; {
+              description = "GitHub Notifications notifier for Linux";
+              homepage = "https://github.com/axelkar/gh-notifier";
+              license = licenses.asl20;
+            };
+          };
+        }
+      );
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            strictDeps = true;
+            RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+            nativeBuildInputs = with pkgs; [
+              cargo
+              rustc
+              pkg-config
+
+              rustfmt
+              clippy
+              rust-analyzer
+            ];
+
+            inherit (self.packages.${system}.default) buildInputs;
+          };
+        }
+      );
+      nixosModules.default = { config, lib, pkgs, ... }:
+        let
+          cfg = config.services.gh-notifier;
+        in
+        {
+          imports = [ sharedOptionModule ];
+
+          config = lib.mkIf cfg.enable {
+            systemd.user.services.gh-notifier = {
+              description = "GitHub Notifications notifier for Linux";
+              partOf = [ cfg.systemdTarget ];
+              after = [ cfg.systemdTarget ]; # Make sure a notification daemon is running
+
+              serviceConfig = {
+                Restart = "on-failure";
+                EnvironmentFile = [ cfg.environmentFile ];
+                ExecStart = "${cfg.package}/bin/gh-notifier";
+              };
+
+              wantedBy = [ cfg.systemdTarget ];
+            };
+          };
+        };
+      homeModules.default = { config, lib, pkgs, ... }:
+        let
+          cfg = config.services.gh-notifier;
+        in
+        {
+          imports = [ sharedOptionModule ];
+
+          config = lib.mkIf cfg.enable {
+            systemd.user.services.gh-notifier = {
+              Unit = {
+                Description = "GitHub Notifications notifier for Linux";
+                PartOf = [ cfg.systemdTarget ];
+                After = [ cfg.systemdTarget ]; # Make sure a notification daemon is running
+              };
+
+              Service = {
+                Restart = "on-failure";
+                EnvironmentFile = [ cfg.environmentFile ];
+                ExecStart = "${cfg.package}/bin/gh-notifier";
+              };
+
+              Install.WantedBy = [ cfg.systemdTarget ];
+            };
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "gh-notifier devel and build";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
 
   # shell.nix compatibility
   inputs.flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
@@ -14,13 +14,12 @@
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
       forAllSystems = nixpkgs.lib.genAttrs targetSystems;
 
-      inherit (nixpkgs) lib;
       sharedOptionModule = { lib, pkgs, ... }: {
         options.services.gh-notifier = {
           enable = lib.mkEnableOption "GitHub Notifications notifier for Linux";
           package = lib.mkOption {
             type = lib.types.package;
-            default = self.packages.${pkgs.system}.default;
+            default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
             defaultText = lib.literalMD "`gh-notifier` from the flake defining this module";
             description = ''
               Package to use.
@@ -61,7 +60,7 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          default = pkgs.rustPlatform.buildRustPackage rec {
+          default = pkgs.rustPlatform.buildRustPackage {
             pname = "gh-notifier";
             version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
 
@@ -113,7 +112,7 @@
           };
         }
       );
-      nixosModules.default = { config, lib, pkgs, ... }:
+      nixosModules.default = { config, lib, ... }:
         let
           cfg = config.services.gh-notifier;
         in
@@ -136,7 +135,7 @@
             };
           };
         };
-      homeModules.default = { config, lib, pkgs, ... }:
+      homeModules.default = { config, lib, ... }:
         let
           cfg = config.services.gh-notifier;
         in

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+      nodeName = lock.nodes.root.inputs.flake-compat;
+    in
+    fetchTarball {
+      url = lock.nodes.${nodeName}.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+      sha256 = lock.nodes.${nodeName}.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
- [Nix, the package manager](https://nix.dev/#what-can-you-do-with-nix)
- [NixOS](https://nixos.org)
- [Home Manager](https://nix-community.github.io/home-manager/index.xhtml#ch-introduction)

You may want to document these in the README. I added a development environment, a package and modules for both NixOS and Home Manager, which can be used with the following and its NixOS equivalent. I'll test `xdg-open`'s functionality.
```nix
{ ... }:
{
  imports = [ inputs.gh-notifier.homeModules.default ];
  services.gh-notifier = {
    enable = true;
    environmentFile = "/home/axel/.local/state/gh-notifier.env"; # or /run/user/$(id -u)/secrets/gh-notifier.env with a secret management scheme
  };
}
```